### PR TITLE
Add raster legend

### DIFF
--- a/ShinyApps/LeafletApp/styles.css
+++ b/ShinyApps/LeafletApp/styles.css
@@ -39,7 +39,7 @@ h1, h2, h3, h4 { font-weight: 400; }
 #cite {
   position: absolute;
   bottom: 10px;
-  left: 10px;
+  left: 150px;
   font-size: 12px;
 }
 


### PR DESCRIPTION
Added raster legend, updated some comments, and also removed feature that made the lowest quintile of the raster transparent. The transparency created NA values in the raster, which were displayed oddly in the legend. Moved the "Data compiled for TEAM" text slightly right to avoid overlap with legend.